### PR TITLE
backend: Add genCoupons helper, other cleanups

### DIFF
--- a/backend/test-config.yaml
+++ b/backend/test-config.yaml
@@ -3,11 +3,10 @@
 questionsFile: "test-questions.json"                                                  # File containing questions in JSON format
 couponsFile: "test-coupons.txt"                                                       # File containing coupons, one per line
 nativeReward: "2.0"                                                                   # Reward in ROSE (optional)
-# gaslessAddress: "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"                          # Gasless address (optional)
-# gaslessSecret: "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a"   # Gasless account private key (optional)
-# fundGaslessAmount: "10"                                                               # Amount of ROSE to send to gasless account (optional)
+gaslessSecret: "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a"   # Gasless account private key (optional)
+fundGaslessAmount: "10"                                                               # Amount of ROSE to send to gasless account (optional)
 fundAmount: "5"                                                                       # Amount in ROSE to fund the contract (optional)
-nftReward:                                                                            # NFT reward (optional)    
+nftReward:                                                                            # NFT reward (optional)
   address: ""                                                                         # Address of the existing NFT contract (if exists)
   metadataFile: "test/assets/metadata_inline.json"                                    # Metadata File
   name: "Quiz"                                                                        # Name of the NFT collection (for new contract)


### PR DESCRIPTION
This PR adds:
- genCoupons() lets you generate n coupons of length l
- rename fundContract() -> fundAccount since it can be used for any address
- remove fundGaslessAccount() since it's redundant ^^
- setGaslessKeypair() doesn't require address anymore, becuase it can be derived from the secret directly